### PR TITLE
Modify kfocus-power-set and qml-power-app to work more smoothly together

### DIFF
--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -164,7 +164,11 @@ _scanFn () {
         _solve_line="${_label};${_set_max_int};${_gov_key};";
         _solve_line+="${_noturbo_int};";
         if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
-          _solve_line+="${_kbdled_int};";
+          if [ "${_kbdled_int}" = '1' ]; then
+            _solve_line+="On;";
+          else
+            _solve_line+="Off;";
+          fi
         fi
         _prior_max_int="${_set_max_int}"
       fi

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -12,6 +12,8 @@
 #
 set -u;
 
+_optionHeader='Profile;Frequency;Governor;Turbo;LEDs'
+
 _optionTable=(
   # _label;up_ratio;down_ratio;gov_key;noturbo_int;kbdled_int
   'High;1;X;performance;0;1'
@@ -213,7 +215,23 @@ _setModeFn () {
 }
 
 _printOptionsFn () {
-  declare _opt_line;
+  declare _opt_line _header_line _bit_list _label _frequency _governor \
+  _turbo _leds;
+
+  IFS=';' read -r -a _bit_list <<< "${_optionHeader}";
+  _label="${_bit_list[0]}";
+  _frequency="${_bit_list[1]}";
+  _governor="${_bit_list[2]}";
+  _turbo="${_bit_list[3]}";
+  _leds="${_bit_list[4]}";
+
+  _header_line="${_label};${_frequency};${_governor};${_turbo};";
+  if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+    _header_line+="${_leds};";
+  fi
+
+  echo "${_header_line}";
+
   for _opt_line in "${_optionTable[@]}"; do
     _scanFn "${_opt_line}" 'print';
   done

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -13,7 +13,7 @@
 set -u;
 
 _optionTable=(
-  # _label;_power_idx;up_ratio;down_ratio;gov_key;noturbo_int;kbdled_int
+  # _label;up_ratio;down_ratio;gov_key;noturbo_int;kbdled_int
   'High;1;X;performance;0;1'
   'Normal;1;X;powersave;0;1'
   'Studio;0;X;performance;1;1'

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -125,7 +125,7 @@ _scanFn () {
   _kbdled_int="${_bit_list[5]}";
 
   case "${_mode_key}" in
-    print|read) true;;
+    print|read|readInternal) true;;
     set)
       _setNoTurboFn "${_noturbo_int}";
       _setKeyboardFn "${_kbdled_int}";
@@ -159,21 +159,26 @@ _scanFn () {
     );
     _set_max_int="$(_printMaxIntFn "${_param_list[@]}")";
 
-    if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
+    if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ] || \
+      [ "${_mode_key}" = 'readInternal' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
         _solve_line="${_label};"
-        _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
-        _solve_line+="${_gov_key};";
-        if [ "${_noturbo_int}" = '1' ]; then
-          _solve_line+="No;";
+        if [ "${_mode_key}" = 'readInternal' ]; then
+          _solve_line+="${_set_max_int};${_gov_key};${_noturbo_int};${_kbdled_int};";
         else
-          _solve_line+="Yes;";
-        fi
-        if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
-          if [ "${_kbdled_int}" = '1' ]; then
-            _solve_line+="On;";
+          _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
+          _solve_line+="${_gov_key};";
+          if [ "${_noturbo_int}" = '1' ]; then
+            _solve_line+="No;";
           else
-            _solve_line+="Off;";
+            _solve_line+="Yes;";
+          fi
+          if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+            if [ "${_kbdled_int}" = '1' ]; then
+              _solve_line+="On;";
+            else
+              _solve_line+="Off;";
+            fi
           fi
         fi
         _prior_max_int="${_set_max_int}"
@@ -194,7 +199,8 @@ _scanFn () {
     fi
   done
 
-  if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
+  if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ] || \
+    [ "${_mode_key}" = 'readInternal' ]; then
     echo "${_solve_line}";
   fi
 }
@@ -279,7 +285,7 @@ _readModeFn () {
   if [ -z "${_search_line:-}" ]; then return 1; fi
 
   for _opt_line in "${_optionTable[@]}"; do
-    _read_line="$(_scanFn "${_opt_line}" 'read')";
+    _read_line="$(_scanFn "${_opt_line}" 'readInternal')";
     IFS=';' read -r -d '' -a _bit_list < <(echo -n "${_read_line}");
     if [ "${_bit_list[*]:1:3}" = "${_search_line}" ]; then
       echo "${_bit_list[0]}";

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -23,6 +23,24 @@ _optionTable=(
   'Minimal;X;.5;powersave;1;0'
 );
 
+## BEGIN _importCommonFn {
+# Imports: _cm2EchoModelStrFn _cm2KdiagExe _cm2WarnStrFn
+#
+# Run ls-common-symbols.sh to get this list
+#
+_importCommonFn () {
+  declare _lib_file;
+  _lib_file="${_baseDir}/lib/common.2.source";
+  if [ -r "${_lib_file}" ]; then
+    # shellcheck source=../lib/common.2.source
+    source "${_lib_file}" || exit 202;
+  else
+    echo 1>&2 "${_baseName}: ABORT - Cannot source lib |${_lib_file}|";
+    exit 202;
+  fi  
+}
+## . END _importCommonFn }
+
 _printIntFn () { printf '%.0f' "$*"; }
 _stderrFn () { 1>&2 echo -e "$*"; }
 _printMaxIntFn () {
@@ -142,7 +160,10 @@ _scanFn () {
     if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
         _solve_line="${_label};${_set_max_int};${_gov_key};";
-        _solve_line+="${_noturbo_int};${_kbdled_int};";
+        _solve_line+="${_noturbo_int};";
+        if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+          _solve_line+="${_kbdled_int};";
+        fi
         _prior_max_int="${_set_max_int}"
       fi
     else
@@ -279,6 +300,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   _binDir="$(dirname "${_binName}")"    || exit 101;
   _baseDir="$(dirname "${_binDir}")"    || exit 101;
   _baseName="$(basename "${_binName}")" || exit 101;
+  _importCommonFn;
   _mainFn "$@";
 fi
 ## . END Run main if script is not sourced }

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -162,7 +162,11 @@ _scanFn () {
     if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
         _solve_line="${_label};${_set_max_int};${_gov_key};";
-        _solve_line+="${_noturbo_int};";
+        if [ "${_noturbo_int}" = '1' ]; then
+          _solve_line+="No;";
+        else
+          _solve_line+="Yes;";
+        fi
         if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
           if [ "${_kbdled_int}" = '1' ]; then
             _solve_line+="On;";

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -161,7 +161,9 @@ _scanFn () {
 
     if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
-        _solve_line="${_label};${_set_max_int};${_gov_key};";
+        _solve_line="${_label};"
+        _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
+        _solve_line+="${_gov_key};";
         if [ "${_noturbo_int}" = '1' ]; then
           _solve_line+="No;";
         else

--- a/research/qml-power-app/main.qml
+++ b/research/qml-power-app/main.qml
@@ -179,7 +179,7 @@ Kirigami.ApplicationWindow {
         // Loads and parse the available profiles
         PlasmaCore.DataSource {
             engine: "executable"
-            connectedSources: ['echo "Profile;GHz;Governor;;LEDs"; /usr/lib/kfocus/bin/kfocus-power-set -p']
+            connectedSources: ['/usr/lib/kfocus/bin/kfocus-power-set -p']
             onNewData: {
                 let stdout = data["stdout"]
                 stdout.split('\n').forEach(function (line, index) {


### PR DESCRIPTION
Merge target set to a new feature branch, should be safe to merge.

This is basically picking up where we left off with https://github.com/kfocus/kfocus-source/pull/3. I have implemented all of the requested features in `kfocus-power-set -p`, attempting to follow the coding style in the rest of the script. I also threw in a couple of extra things I felt would be helpful based on what I had seen elsewhere in the code or in the requested features. I have tested this to a degree, however as I do not have a KFocus laptop with keyboard LEDs, I was not able to fully test the keyboard LED features (though I did some testing with the help of commenting out an if/then statement temporarily).

I have not yet tested/fixed display scaling in qml-power-app - it's almost 4:30 AM where I am so I stopped here. Hopefully I can work on that later, maybe on Monday.

Full list of changes:

* kfocus-power-set now imports common.2.source in order to use its hardware detection features.
* Said hardware detection features are used to detect if the host machine has keyboard LEDs that can be controlled via the power tools. If not, keyboard LED info is not output when `kfocus-power-set -p` is run.
* The header line that was once baked into qml-power-app has been moved to kfocus-power-set. It adjusts in response to the host machine's hardware just like the rest of the output, so an LED column will not be output if keyboard LEDs aren't supported.
* When LED info is output, it now reads "On" or "Off" rather than "1" or "0".
* Ditto for the Turbo value.
* Made frequency values be specified as things like "2.40 GHz" rather than "2400000".
* Added a "readInternal" feature to `_scanFn` for use with `_readModeFn` - this avoids regressing `_readModeFn` with the modified output of `_scanFn`.
* Off-topic, but there was a comment in `_optionTable` that appeared to have an obsolete or incorrect `_power_idx` field specified in it that didn't actually exist in the table. I snipped out that field from the comment.