### PR TITLE
Restore old API functionality, preserving qml-power-app's functionality, plus unit test overhaul

### DIFF
--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -230,8 +230,10 @@ _setModeFn () {
 }
 
 _printOptionsFn () {
-  declare _opt_line _header_line _bit_list _label _frequency _governor \
-  _turbo _leds;
+  declare _print_mode _opt_line _header_line _bit_list _label _frequency \
+  _governor _turbo _leds;
+
+  _print_mode="${1:-}"
 
   IFS=';' read -r -a _bit_list <<< "${_optionHeader}";
   _label="${_bit_list[0]}";
@@ -240,15 +242,20 @@ _printOptionsFn () {
   _turbo="${_bit_list[3]}";
   _leds="${_bit_list[4]}";
 
-  _header_line="${_label};${_frequency};${_governor};${_turbo};";
-  if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
-    _header_line+="${_leds};";
+  if [ "${_print_mode}" = 'x' ]; then
+    _header_line="${_label};${_frequency};${_governor};${_turbo};";
+    if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+      _header_line+="${_leds};";
+    fi
+    echo "${_header_line}";
   fi
 
-  echo "${_header_line}";
-
   for _opt_line in "${_optionTable[@]}"; do
-    _scanFn "${_opt_line}" 'print';
+    if [ "${_print_mode}" = 'x' ]; then
+      _scanFn "${_opt_line}" 'print';
+    else
+      _scanFn "${_opt_line}" 'read';
+    fi
   done
 }
 ## . END _printOptionsFn }
@@ -303,7 +310,8 @@ _mainFn () {
   declare _arg_str;
   _arg_str="${1:-}";
   case "${_arg_str}" in
-    '-p') _printOptionsFn;;
+    '-p') _printOptionsFn 'p';;
+    '-x') _printOptionsFn 'x';;
     '-r') _readModeFn;;
       '') _stderrFn 'Argument or flag required'; exit 1;;
        *) _setModeFn "${_arg_str}";

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -170,9 +170,9 @@ _scanFn () {
           _solve_line+="${_gov_key};";
           if [ "${_noturbo_int}" = '1' ]; then
             _solve_line+="No;";
-         else
+          else
             _solve_line+="Yes;";
-         fi
+          fi
           if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
             if [ "${_kbdled_int}" = '1' ]; then
               _solve_line+="On;";

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -161,19 +161,24 @@ _scanFn () {
 
     if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
-        _solve_line="${_label};"
-        _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
-        _solve_line+="${_gov_key};";
-        if [ "${_noturbo_int}" = '1' ]; then
-          _solve_line+="No;";
+        if [ "${_mode_key}" = 'read' ]; then
+          _solve_line="${_label};${_set_max_int};${_gov_key};${_noturbo_int};";
+          _solve_line+="${_kbdled_int};";
         else
-          _solve_line+="Yes;";
-        fi
-        if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
-          if [ "${_kbdled_int}" = '1' ]; then
-            _solve_line+="On;";
-          else
-            _solve_line+="Off;";
+          _solve_line="${_label};";
+          _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;";
+          _solve_line+="${_gov_key};";
+          if [ "${_noturbo_int}" = '1' ]; then
+            _solve_line+="No;";
+         else
+            _solve_line+="Yes;";
+         fi
+          if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+            if [ "${_kbdled_int}" = '1' ]; then
+              _solve_line+="On;";
+            else
+              _solve_line+="Off;";
+            fi
           fi
         fi
         _prior_max_int="${_set_max_int}"

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -125,7 +125,7 @@ _scanFn () {
   _kbdled_int="${_bit_list[5]}";
 
   case "${_mode_key}" in
-    print|read|readInternal) true;;
+    print|read) true;;
     set)
       _setNoTurboFn "${_noturbo_int}";
       _setKeyboardFn "${_kbdled_int}";
@@ -159,26 +159,21 @@ _scanFn () {
     );
     _set_max_int="$(_printMaxIntFn "${_param_list[@]}")";
 
-    if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ] || \
-      [ "${_mode_key}" = 'readInternal' ]; then
+    if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
       if [ "${_set_max_int}" -gt "${_prior_max_int}" ]; then
         _solve_line="${_label};"
-        if [ "${_mode_key}" = 'readInternal' ]; then
-          _solve_line+="${_set_max_int};${_gov_key};${_noturbo_int};${_kbdled_int};";
+        _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
+        _solve_line+="${_gov_key};";
+        if [ "${_noturbo_int}" = '1' ]; then
+          _solve_line+="No;";
         else
-          _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;"
-          _solve_line+="${_gov_key};";
-          if [ "${_noturbo_int}" = '1' ]; then
-            _solve_line+="No;";
+          _solve_line+="Yes;";
+        fi
+        if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
+          if [ "${_kbdled_int}" = '1' ]; then
+            _solve_line+="On;";
           else
-            _solve_line+="Yes;";
-          fi
-          if [ "$(_cm2EchoModelStrFn 'has_kb_led')" = 'y' ]; then
-            if [ "${_kbdled_int}" = '1' ]; then
-              _solve_line+="On;";
-            else
-              _solve_line+="Off;";
-            fi
+            _solve_line+="Off;";
           fi
         fi
         _prior_max_int="${_set_max_int}"
@@ -199,8 +194,7 @@ _scanFn () {
     fi
   done
 
-  if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ] || \
-    [ "${_mode_key}" = 'readInternal' ]; then
+  if [ "${_mode_key}" = 'print' ] || [ "${_mode_key}" = 'read' ]; then
     echo "${_solve_line}";
   fi
 }
@@ -285,7 +279,7 @@ _readModeFn () {
   if [ -z "${_search_line:-}" ]; then return 1; fi
 
   for _opt_line in "${_optionTable[@]}"; do
-    _read_line="$(_scanFn "${_opt_line}" 'readInternal')";
+    _read_line="$(_scanFn "${_opt_line}" 'read')";
     IFS=';' read -r -d '' -a _bit_list < <(echo -n "${_read_line}");
     if [ "${_bit_list[*]:1:3}" = "${_search_line}" ]; then
       echo "${_bit_list[0]}";

--- a/research/qml-power-app/main.qml
+++ b/research/qml-power-app/main.qml
@@ -179,7 +179,7 @@ Kirigami.ApplicationWindow {
         // Loads and parse the available profiles
         PlasmaCore.DataSource {
             engine: "executable"
-            connectedSources: ['/usr/lib/kfocus/bin/kfocus-power-set -p']
+            connectedSources: ['/usr/lib/kfocus/bin/kfocus-power-set -x']
             onNewData: {
                 let stdout = data["stdout"]
                 stdout.split('\n').forEach(function (line, index) {

--- a/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_p.txt
+++ b/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_p.txt
@@ -1,0 +1,7 @@
+High;4200000;performance;0;1;
+Normal;4200000;powersave;0;1;
+Studio;2400000;performance;1;1;
+Medium;3300000;powersave;0;1;
+Low;2400000;powersave;1;0;
+Frugal;1733333;powersave;1;0;
+Minimal;1400000;powersave;1;0;

--- a/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_x.txt
+++ b/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_x.txt
@@ -1,0 +1,8 @@
+Profile;Frequency;Governor;Turbo;
+High;4.20 GHz;performance;Yes;
+Normal;4.20 GHz;powersave;Yes;
+Studio;2.40 GHz;performance;No;
+Medium;3.30 GHz;powersave;Yes;
+Low;2.40 GHz;powersave;No;
+Frugal;1.73 GHz;powersave;No;
+Minimal;1.40 GHz;powersave;No;

--- a/test/test-script/unit.d/00700_kfocusPowerSet
+++ b/test/test-script/unit.d/00700_kfocusPowerSet
@@ -137,25 +137,20 @@ _echoCpuModelNameFn () {
   echo "${_cpu_name}";
 }
 
-## BEGIN _runTestFn {
-_runTestFn () {
-  declare _cr _cpu_name _power_exe _current_mode_str _pick_str _pick_list \
-    _model_code _test_count _test_idx _fail_count _mode_str _descr_str \
-    _expect_str _check_str _run_str _expect_file _run_file;
-
-  # Use function from _runUnitTests: clear out run dir and check expect dir
-  if ! _t00ClearRunDirFn;    then return 1; fi
-  if ! _t00CheckExpectDirFn; then return 1; fi
+## BEGIN _testLoopFn {
+_testLoopFn () {
+  declare _cr _cpu_name _pick_list _pick_str _power_exe _model_code \
+    _test_count _test_idx _fail_count _mode_str _expect_file _run_file \
+    _descr_str _expect_str _run_str _check_str
 
   _cr=$'\n';
   _cpu_name="$(_echoCpuModelNameFn)";
 
+  _pick_list=( "$@" )
+
   # shellcheck disable=SC1090,SC2154
   _power_exe="${_t00TopDir}/package-tools/usr/lib/kfocus/";
   _power_exe+='bin/kfocus-power-set';
-  _current_mode_str="$("${_power_exe}" -r)";
-  _pick_str="$("${_power_exe}" -p)";
-  IFS=$'\n' read -r -d '' -a _pick_list <<<"${_pick_str}";
 
   _model_code="$(_cm2EchoModelStrFn 'code')";
   _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
@@ -212,6 +207,33 @@ _runTestFn () {
     fi
   done
 
+  return "${_fail_count}";
+}
+## . END _testLoopFn }
+
+## BEGIN _runTestFn {
+_runTestFn () {
+  declare _power_exe _current_mode_str _pick_str _pick_list _fail_count \
+    _test_count;
+
+  # Use function from _runUnitTests: clear out run dir and check expect dir
+  if ! _t00ClearRunDirFn;    then return 1; fi
+  if ! _t00CheckExpectDirFn; then return 1; fi
+  
+  # shellcheck disable=SC1090,SC2154
+  _power_exe="${_t00TopDir}/package-tools/usr/lib/kfocus/";
+  _power_exe+='bin/kfocus-power-set';
+  _current_mode_str="$("${_power_exe}" -r)";
+
+  _cm2EchoFn "TEST SUITE 1: kfocus-power-set -p parsing and execution\n";
+  
+  _pick_str="$("${_power_exe}" -p)";
+  IFS=$'\n' read -r -d '' -a _pick_list <<<"${_pick_str}";
+
+  _testLoopFn "${_pick_list[@]}"
+  _fail_count="$?"
+  _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
+  
   if [ "${_fail_count}" -gt 0 ]; then
     _cm2EchoFn "fail: ${_fail_count} of ${_test_count} tests failed.";
   else

--- a/test/test-script/unit.d/00700_kfocusPowerSet
+++ b/test/test-script/unit.d/00700_kfocusPowerSet
@@ -240,6 +240,22 @@ _runTestFn () {
     _cm2EchoFn 'ok  : Results match expected';
   fi
 
+  _cm2EchoFn "TEST SUITE 2: kfocus-power-set -x parsing and execution\n";
+
+  _pick_str="$("${_power_exe}" -x)";
+  IFS=$'\n' read -r -d '' -a _pick_list <<<"${_pick_str}";
+  _pick_list=("${_pick_list[@]:1}") # Remove the header
+
+  _testLoopFn "${_pick_list[@]}"
+   _fail_count="$?"
+  _test_count="$(echo "${#_pick_list[@]}*2"|bc)"
+
+  if [ "${_fail_count}" -gt 0 ]; then
+    _cm2EchoFn "fail: ${_fail_count} of ${_test_count} tests failed.";
+  else
+    _cm2EchoFn 'ok  : Results match expected';
+  fi;
+
   if [ "${_current_mode_str:0:6}" = 'Custom' ]; then
     _current_mode_str='Normal';
     _cm2EchoFn "Warn: Switch from Custom to Normal Mode";

--- a/test/test-script/unit.d/00700_kfocusPowerSet
+++ b/test/test-script/unit.d/00700_kfocusPowerSet
@@ -248,7 +248,7 @@ _testApiFn () {
 ## BEGIN _runTestFn {
 _runTestFn () {
   declare _power_exe _current_mode_str _pick_str _pick_list _fail_count \
-    _test_count;
+    _test_count _total_fail_count;
 
   # Use function from _runUnitTests: clear out run dir and check expect dir
   if ! _t00ClearRunDirFn;    then return 1; fi
@@ -258,6 +258,7 @@ _runTestFn () {
   _power_exe="${_t00TopDir}/package-tools/usr/lib/kfocus/";
   _power_exe+='bin/kfocus-power-set';
   _current_mode_str="$("${_power_exe}" -r)";
+  _total_fail_count=0
 
   _cm2EchoFn "TEST SUITE 1: kfocus-power-set -p API check\n";
 
@@ -266,6 +267,7 @@ _runTestFn () {
 
   _testApiFn 'p' "${_pick_list[@]}";
   _fail_count="$?";
+  _total_fail_count=$((_total_fail_count+_fail_count))
   _test_count="1";
 
   if [ "${_fail_count}" -gt 0 ]; then
@@ -278,6 +280,7 @@ _runTestFn () {
 
   _testLoopFn "${_pick_list[@]}";
   _fail_count="$?";
+  _total_fail_count=$((_total_fail_count+_fail_count))
   _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
   
   if [ "${_fail_count}" -gt 0 ]; then
@@ -293,6 +296,7 @@ _runTestFn () {
  
   _testApiFn 'x' "${_pick_list[@]}";
   _fail_count="$?";
+  _total_fail_count=$((_total_fail_count+_fail_count))
   _test_count="1";
 
   if [ "${_fail_count}" -gt 0 ]; then
@@ -307,6 +311,7 @@ _runTestFn () {
 
   _testLoopFn "${_pick_list[@]}";
   _fail_count="$?";
+  _total_fail_count=$((_total_fail_count+_fail_count))
   _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
 
   if [ "${_fail_count}" -gt 0 ]; then
@@ -324,6 +329,6 @@ _runTestFn () {
 
   sudo "${_power_exe}" "${_current_mode_str}";
 
-  return "${_fail_count}";
+  return "${_total_fail_count}";
 }
 ## . END _runTestFn }

--- a/test/test-script/unit.d/00700_kfocusPowerSet
+++ b/test/test-script/unit.d/00700_kfocusPowerSet
@@ -211,6 +211,40 @@ _testLoopFn () {
 }
 ## . END _testLoopFn }
 
+## BEGIN _testApiFn {
+_testApiFn () {
+  declare _pick_list _api_mode_ _model_code _cpu_name _field_list \
+    _expect_file _run_file _expect_str _run_str
+
+  _pick_list=( "$@" );
+  _api_mode="${_pick_list[0]}";
+  _pick_list=("${_pick_list[@]:1}"); # Remove the API mode argument
+  _model_code="$(_cm2EchoModelStrFn 'code')";
+  _cpu_name="$(_echoCpuModelNameFn)";
+  _field_list=( "${_model_code}" "${_cpu_name}" "api_str_${_api_mode}" );
+
+  _expect_file="$(
+    printf '%s/%s_%s_%s.txt' "${_t00ExpectDir}" "${_field_list[@]}"
+  )";
+  _run_file="$(
+    printf '%s/%s_%s_%s.txt' "${_t00RunDir}" "${_field_list[@]}"
+  )";
+  if [ ! -f "${_expect_file}" ]; then touch "${_expect_file}"; fi
+  if [ ! -f "${_run_file}"    ]; then touch "${_run_file}";    fi
+  _expect_str="$(cat "${_expect_file}")";
+  _run_str="$(IFS=$'\n'; echo "${_pick_list[*]}")";
+  echo "${_run_str}" > "${_run_file}";
+  if [ "${_expect_str}" = "${_run_str}" ]; then
+    _cm2EchoFn "OK  Test testApi -${_api_mode}\n\n";
+    return 0;
+  else
+    _cm2EchoFn ". FAIL Test testApi -${_api_mode}\n\n";
+    meld "${_expect_file}" "${_run_file}";
+    return 1;
+  fi
+}
+## . END _testApiFn }
+
 ## BEGIN _runTestFn {
 _runTestFn () {
   declare _power_exe _current_mode_str _pick_str _pick_list _fail_count \
@@ -225,13 +259,25 @@ _runTestFn () {
   _power_exe+='bin/kfocus-power-set';
   _current_mode_str="$("${_power_exe}" -r)";
 
-  _cm2EchoFn "TEST SUITE 1: kfocus-power-set -p parsing and execution\n";
-  
+  _cm2EchoFn "TEST SUITE 1: kfocus-power-set -p API check\n";
+
   _pick_str="$("${_power_exe}" -p)";
   IFS=$'\n' read -r -d '' -a _pick_list <<<"${_pick_str}";
 
-  _testLoopFn "${_pick_list[@]}"
-  _fail_count="$?"
+  _testApiFn 'p' "${_pick_list[@]}";
+  _fail_count="$?";
+  _test_count="1";
+
+  if [ "${_fail_count}" -gt 0 ]; then
+    _cm2EchoFn "fail: ${_fail_count} of ${_test_count} tests failed.";
+  else
+    _cm2EchoFn 'ok  : Results match expected';
+  fi
+
+  _cm2EchoFn "TEST SUITE 2: kfocus-power-set -p parsing and execution\n";
+
+  _testLoopFn "${_pick_list[@]}";
+  _fail_count="$?";
   _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
   
   if [ "${_fail_count}" -gt 0 ]; then
@@ -240,15 +286,28 @@ _runTestFn () {
     _cm2EchoFn 'ok  : Results match expected';
   fi
 
-  _cm2EchoFn "TEST SUITE 2: kfocus-power-set -x parsing and execution\n";
+  _cm2EchoFn "TEST SUITE 3: kfocus-power-set -x API check\n"
 
   _pick_str="$("${_power_exe}" -x)";
   IFS=$'\n' read -r -d '' -a _pick_list <<<"${_pick_str}";
-  _pick_list=("${_pick_list[@]:1}") # Remove the header
+ 
+  _testApiFn 'x' "${_pick_list[@]}";
+  _fail_count="$?";
+  _test_count="1";
 
-  _testLoopFn "${_pick_list[@]}"
-   _fail_count="$?"
-  _test_count="$(echo "${#_pick_list[@]}*2"|bc)"
+  if [ "${_fail_count}" -gt 0 ]; then
+    _cm2EchoFn "fail: ${_fail_count} of ${_test_count} tests failed.";
+  else
+    _cm2EchoFn 'ok  : Results match expected';
+  fi
+
+  _cm2EchoFn "TEST SUITE 4: kfocus-power-set -x parsing and execution\n";
+
+  _pick_list=("${_pick_list[@]:1}"); # Remove the header
+
+  _testLoopFn "${_pick_list[@]}";
+  _fail_count="$?";
+  _test_count="$(echo "${#_pick_list[@]}*2"|bc)";
 
   if [ "${_fail_count}" -gt 0 ]; then
     _cm2EchoFn "fail: ${_fail_count} of ${_test_count} tests failed.";


### PR DESCRIPTION
Full list of changes:

* Got rid of the "readInternal" mode of _scanFn - it turns out "read" and "print" were doing identical things and so there's no need for an extra mode when there's a somewhat unused one available.
* Made _scanFn's "read" mode behave as it did originally before we started messing with kfocus-power-set for the QML app. The new behavior that qml-power-app relies on is now handled by the "print" mode.
* Made the -p switch behave as it did originally. The new behavior that qml-power-app relies on is now handled by the -x switch.
* Made qml-power-app use the -x switch instead of the -p switch now that the functionality it needs is triggered by that switch.
* Overhauled the kfocus-power-set unit tests. The output of both -p and -x are parsed and the results executed to ensure that the system behaves as intended when doing so, while the exact output of both -p and -x is compared with expected values to detect API changes. To avoid code duplication, this included a large amount of refactoring - the _runTestFn function now acts as a sort of "commander" function that delegates the actual test running to _testLoopFn and _testApiFn, two new functions.
* Added working "expect" files for the API unit tests, for the XEg1_i5-1135g7 machine. Other machines will need to have their "expect" files added.

This PR makes the qml-power-app feature branch no longer break the existing kfocus-power app (since -p now behaves as it did before).