### PR TITLE
More enhancements

### DIFF
--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -7,10 +7,10 @@ import org.kde.plasma.core 2.1 as PlasmaCore
 Kirigami.ApplicationWindow {
     id: root
     title: "Kubuntu Focus Power Tool"
-    width: 550
-    height: 590
-    minimumWidth: 550
-    minimumHeight: 590
+    width: 560
+    height: 650
+    minimumWidth: 560
+    minimumHeight: 650
 
     pageStack.initialPage: Kirigami.Page {
         title: "KFocus Power and Fan"

--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -8,9 +8,9 @@ Kirigami.ApplicationWindow {
     id: root
     title: "Kubuntu Focus Power Tool"
     width: 560
-    height: 650
+    height: 670
     minimumWidth: 560
-    minimumHeight: 650
+    minimumHeight: 670
 
     pageStack.initialPage: Kirigami.Page {
         title: "KFocus Power and Fan"
@@ -106,7 +106,11 @@ Kirigami.ApplicationWindow {
                         }
                     }
                 }
-                Layout.bottomMargin: PlasmaCore.Units.largeSpacing
+            }
+
+            Controls.Label {
+              text: "psave = powersave, PERF = performance"
+              Layout.bottomMargin: PlasmaCore.Units.largeSpacing
             }
 
             Kirigami.Heading {
@@ -246,7 +250,7 @@ Kirigami.ApplicationWindow {
                     if (line === '') return;
                     if (line.substring(0, 5) == "title") {
                         fanMissingMsg = true;
-                        root.height = 665
+                        root.height = 700
                         let lineParts = line.split('|');
                         let titleMsg = lineParts[0].split(':')[1];
                         let bodyMsg = lineParts[1].split(':')[1];

--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -42,6 +42,7 @@ Kirigami.ApplicationWindow {
             }
 
             RowLayout {
+                visible: plasmaProfilesSlider.visible
                 spacing: 0
                 Layout.fillWidth: true
 

--- a/package-tools/usr/lib/kfocus/bin/kfocus-power-set
+++ b/package-tools/usr/lib/kfocus/bin/kfocus-power-set
@@ -167,7 +167,11 @@ _scanFn () {
         else
           _solve_line="${_label};";
           _solve_line+="${_set_max_int:0:1}.${_set_max_int:1:2} GHz;";
-          _solve_line+="${_gov_key};";
+          if [ "${_gov_key}" = 'powersave' ]; then
+            _solve_line+="psave;";
+          else
+            _solve_line+="PERF;";
+          fi
           if [ "${_noturbo_int}" = '1' ]; then
             _solve_line+="No;";
           else

--- a/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_p.txt
+++ b/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_p.txt
@@ -1,7 +1,5 @@
 High;4200000;performance;0;1;
 Normal;4200000;powersave;0;1;
 Studio;2400000;performance;1;1;
-Medium;3300000;powersave;0;1;
 Low;2400000;powersave;1;0;
-Frugal;1733333;powersave;1;0;
 Minimal;1400000;powersave;1;0;

--- a/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_x.txt
+++ b/test/test-data/expect/00700_kfocusPowerSet/xeg1_i5-1135G7_api_str_x.txt
@@ -1,8 +1,6 @@
 Profile;Frequency;Governor;Turbo;
-High;4.20 GHz;performance;Yes;
-Normal;4.20 GHz;powersave;Yes;
-Studio;2.40 GHz;performance;No;
-Medium;3.30 GHz;powersave;Yes;
-Low;2.40 GHz;powersave;No;
-Frugal;1.73 GHz;powersave;No;
-Minimal;1.40 GHz;powersave;No;
+High;4.20 GHz;PERF;Yes;
+Normal;4.20 GHz;psave;Yes;
+Studio;2.40 GHz;PERF;No;
+Low;2.40 GHz;psave;No;
+Minimal;1.40 GHz;psave;No;


### PR DESCRIPTION
* kfocus-power-set -x now returns "PERF" rather than "performance", and "psave" rather than "powersave" in the governor column.
* Increased the window size of kfocus-power-bin.
* Added a bit of explanatory text to kfocus-power-bin so PERF and psave are easily understandable.
* Made everything about Plasma power profiles vanish if they aren't supported by the current hardware (there was only one UI object that needed fixed in this way)
* Updated the API regression test expect data to cope with the new output of kfocus-power-set -x.