### PR TITLE
Start porting away from PlasmaCore.DataSource and fix some other problems

### DIFF
--- a/package-power-bin/debian/control
+++ b/package-power-bin/debian/control
@@ -16,7 +16,9 @@ Depends:      ${misc:Depends},
               kfocus-common,
               cpufrequtils,
               hicolor-icon-theme,
-              policykit-1
+              policykit-1,
+              qml-module-org-kde-kirigami2,
+              plasma-framework
 Description: Utility to change power and fan settings
  This utility is available to switch between several power profiles, processor
  frequency settings, and fan settings.

--- a/package-power-bin/kfocus-power-bin.pro
+++ b/package-power-bin/kfocus-power-bin.pro
@@ -5,7 +5,8 @@ QT += quick
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += \
-        main.cpp
+        main.cpp \
+        shellengine.cpp
 
 RESOURCES += qml.qrc
 QT += quickcontrols2
@@ -20,3 +21,11 @@ QML_DESIGNER_IMPORT_PATH =
 qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /usr/lib/kfocus/bin
 !isEmpty(target.path): INSTALLS += target
+
+# QML/C++ interaction stuff
+CONFIG += qmltypes
+QML_IMPORT_NAME = shellengine
+QML_IMPORT_MAJOR_VERSION = 1
+
+HEADERS += \
+    shellengine.h

--- a/package-power-bin/main.cpp
+++ b/package-power-bin/main.cpp
@@ -2,6 +2,7 @@
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
 #include <QIcon>
+#include "shellengine.h"
 
 int main(int argc, char *argv[])
 {

--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0 as Controls
 import QtQuick.Layouts 1.2
 import org.kde.kirigami 2.13 as Kirigami
 import org.kde.plasma.core 2.1 as PlasmaCore
+import shellengine 1.0
 
 Kirigami.ApplicationWindow {
     id: root
@@ -148,7 +149,7 @@ Kirigami.ApplicationWindow {
                 onValueChanged: {
                     fanTimer.triggeredOnStart = false
                     fanTimer.stop()
-                    fanProfilesChecker.connectSource('pkexec ' + binDir + '/kfocus-fan-set ' + fanProfilesModel.profileNames[value])
+                    altFanProfilesChecker.exec('pkexec ' + binDir + '/kfocus-fan-set ' + fanProfilesModel.profileNames[value])
                     fanDescription.text = "<i>Description:</i> " + fanProfilesModel.profileDescriptions[fanSlider.value]
                     fanTimer.start()
                 }
@@ -193,16 +194,13 @@ Kirigami.ApplicationWindow {
             //  '#006091'].reverse()
             property var gridColors: ['transparent', '#F63114', '#F7941E',
             '#33cc33', '#3caae4', '#006091'].reverse()
-            onSelectedProfileChanged: profilesChecker.connectSource('pkexec '
-            + binDir + '/kfocus-power-set ' + selectedProfile)
+            onSelectedProfileChanged: altProfilesChecker.exec('pkexec ' + binDir + '/kfocus-power-set ' + selectedProfile)
         }
 
         // Loads and parse the available profiles
-        PlasmaCore.DataSource {
-            engine: "executable"
-            connectedSources: [ binDir + '/kfocus-power-set -x']
-            onNewData: {
-                let stdout = data["stdout"]
+        ShellEngine {
+            commandStr: binDir + '/kfocus-power-set -x'
+            onStdoutChanged: {
                 let freqMissingMsg = false
                 let buildStr = ""
                 stdout.split('\n').forEach(function (line, index) {
@@ -246,22 +244,19 @@ Kirigami.ApplicationWindow {
                     powerError.text = buildStr
                     powerError.visible = true
                 }
-                disconnectSource(sourceName)
             }
         }
 
         // Checks the current profile
-        PlasmaCore.DataSource {
-            id: profilesChecker
-            engine: "executable"
-            connectedSources: []
-            onNewData: {
-                if (data["stdout"].trim() !== '' && data["stdout"].trim().substring(0, 6).toLowerCase() != "custom") {
-                    profilesModel.selectedProfile = data["stdout"].trim()
+        ShellEngine {
+            id: altProfilesChecker
+            onStdoutChanged: {
+                if (stdout.trim() !== '' && stdout.trim().substring(0, 6).toLowerCase() != "custom") {
+                    profilesModel.selectedProfile = stdout.trim()
                 }
-                disconnectSource(sourceName)
             }
         }
+
         // This checkes the current profile every 5 seconds
         Timer {
             id: powerTimer
@@ -269,7 +264,7 @@ Kirigami.ApplicationWindow {
             triggeredOnStart: true
             running: true
             repeat: true
-            onTriggered: profilesChecker.connectSource(binDir + '/kfocus-power-set -r')
+            onTriggered: altProfilesChecker.exec(binDir + '/kfocus-power-set -r')
         }
 
         ListModel {
@@ -280,13 +275,12 @@ Kirigami.ApplicationWindow {
         }
 
         // Loads and parse the available fan profiles
-        PlasmaCore.DataSource {
-            engine: "executable"
-            connectedSources: [binDir + '/kfocus-fan-set -x']
-            onNewData: {
+        ShellEngine {
+            commandStr: binDir + '/kfocus-fan-set -x'
+            onStdoutChanged: {
                 let fanMissingMsg = false
                 let buildStr = ""
-                data["stdout"].split('\n').forEach(function (line) {
+                stdout.split('\n').forEach(function (line) {
                     if (line === '') { return; }
                     if (line.substring(0, 5) == "title") {
                         fanMissingMsg = true
@@ -312,30 +306,26 @@ Kirigami.ApplicationWindow {
                     fanSlider.visible = false
                 }
                 fanTimer.running = true
-                disconnectSource(sourceName)
             }
         }
 
-        // Checks the current fan profile
-        PlasmaCore.DataSource {
-            id: fanProfilesChecker
-            engine: "executable"
-            connectedSources: []
-            onNewData: {
-                if (data["stdout"].trim() !== '') {
-                    fanSlider.value = fanProfilesModel.profileNames.indexOf(data["stdout"].trim())
+        ShellEngine {
+            id: altFanProfilesChecker
+            onStdoutChanged: {
+                if (stdout.trim() !== '') {
+                    fanSlider.value = fanProfilesModel.profileNames.indexOf(stdout.trim())
                     fanDescription.text = "<i>Description:</i> " + fanProfilesModel.profileDescriptions[fanSlider.value]
                 }
-                disconnectSource(sourceName)
             }
         }
+
         Timer {
             id: fanTimer
             interval: 5000
             triggeredOnStart: true
             repeat: true
             onTriggered: {
-                fanProfilesChecker.connectSource(binDir + '/kfocus-fan-set -r | cut -d\' \' -f1')
+                altFanProfilesChecker.exec(binDir + '/kfocus-fan-set -r | cut -d\' \' -f1')
             }
         }
     }

--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -251,8 +251,9 @@ Kirigami.ApplicationWindow {
         ShellEngine {
             id: altProfilesChecker
             onStdoutChanged: {
-                if (stdout.trim() !== '' && stdout.trim().substring(0, 6).toLowerCase() != "custom") {
-                    profilesModel.selectedProfile = stdout.trim()
+                let trimmed_stdout = stdout.trim()
+                if (trimmed_stdout !== '' && trimmed_stdout.substring(0, 6).toLowerCase() != "custom") {
+                    profilesModel.selectedProfile = trimmed_stdout
                 }
             }
         }
@@ -312,8 +313,9 @@ Kirigami.ApplicationWindow {
         ShellEngine {
             id: altFanProfilesChecker
             onStdoutChanged: {
-                if (stdout.trim() !== '') {
-                    fanSlider.value = fanProfilesModel.profileNames.indexOf(stdout.trim())
+                let trimmed_stdout = stdout.trim()
+                if (trimmed_stdout !== '') {
+                    fanSlider.value = fanProfilesModel.profileNames.indexOf(trimmed_stdout)
                     fanDescription.text = "<i>Description:</i> " + fanProfilesModel.profileDescriptions[fanSlider.value]
                 }
             }

--- a/package-power-bin/main.qml
+++ b/package-power-bin/main.qml
@@ -286,8 +286,8 @@ Kirigami.ApplicationWindow {
                         fanMissingMsg = true
                         root.height = 700
                         let lineParts = line.split('|')
-                        let titleMsg = lineParts[0].split(':')[1]
-                        let bodyMsg = lineParts[1].split(':')[1]
+                        let titleMsg = lineParts[0].substring(6, lineParts[0].length)
+                        let bodyMsg = lineParts[1].substring(8, lineParts[1].length)
                         fanControlHeading.text = titleMsg
                         buildStr += bodyMsg
                     }

--- a/package-power-bin/shellengine.cpp
+++ b/package-power-bin/shellengine.cpp
@@ -1,0 +1,23 @@
+#include "shellengine.h"
+
+ShellEngine::ShellEngine()
+{
+    connect(this, &ShellEngine::commandStrChanged, this, [=]() { this->exec(m_commandStr); });
+}
+
+void ShellEngine::exec(QString args) {
+    QProcess *proc = new QProcess();
+    QStringList argsList;
+    argsList.append("-c");
+    argsList.append(args);
+    proc->start("bash", argsList);
+    connect(proc, SIGNAL(finished(int)), this, SLOT(triggerStdout()));
+}
+
+void ShellEngine::triggerStdout() {
+    QByteArray result = ((QProcess *)sender())->readAllStandardOutput();
+    QString final = QString::fromUtf8(result);
+    m_stdout = final;
+    sender()->deleteLater();
+    emit stdoutChanged();
+}

--- a/package-power-bin/shellengine.h
+++ b/package-power-bin/shellengine.h
@@ -1,0 +1,34 @@
+#ifndef SHELLENGINE_H
+#define SHELLENGINE_H
+
+#include <QObject>
+#include <QProcess>
+#include <QQueue>
+#include <QtQml/qqml.h>
+
+class ShellEngine : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString stdout READ stdout NOTIFY stdoutChanged)
+    Q_PROPERTY(QString commandStr MEMBER m_commandStr NOTIFY commandStrChanged)
+    QML_ELEMENT
+public:
+    ShellEngine();
+    Q_INVOKABLE void exec(QString args);
+    QString stdout() {
+        return m_stdout;
+    }
+
+signals:
+    void stdoutChanged();
+    void commandStrChanged();
+
+public slots:
+    void triggerStdout();
+
+private:
+    QString m_stdout;
+    QString m_commandStr;
+};
+
+#endif // SHELLENGINE_H


### PR DESCRIPTION
Note that I may have made all these changes to the wrong branch, in which case I'm happy to port them to a different branch, test, and re-submit the PR.

Full changes list:

* Replace the "executable" engine in PlasmaCore.DataSource with a new ShellEngine system written in the C++ part of the code. (Fixes https://github.com/kfocus/kfocus-source/issues/10)
* Add two missing runtime deps.
* Be consistent in how we obtain error messages from kfocus-fan-set and kfocus-power-set. (Previously we used a string split to chunk the shell script messages into usable parts in one place, but used substrings in another place since the error message in the other place had a colon in it. Now instead we use substrings in both places.)